### PR TITLE
Fix verification check in get_values procedure

### DIFF
--- a/packages/acs-tcl/tcl/json-procs.tcl
+++ b/packages/acs-tcl/tcl/json-procs.tcl
@@ -483,7 +483,7 @@ ad_proc util::json::array::create {values} {
 
 ad_proc util::json::array::get_values {item} {
 
-    Verify that the given Tcl structure is an object, and return its
+    Verify that the given Tcl structure is an array, and return its
     values list.
 
 } {


### PR DESCRIPTION
Corrected the verification message to check for an array instead of an object.