### PR TITLE
Add show_required_p and csrf_protection_p to valid_arg

### DIFF
--- a/packages/acs-tcl/tcl/form-processing-procs.tcl
+++ b/packages/acs-tcl/tcl/form-processing-procs.tcl
@@ -604,7 +604,7 @@ ad_proc -public ad_form {
             if {$valid_arg ni {
                 name form method action html validate export mode cancel_url
                 has_edit has_submit actions edit_buttons display_buttons
-                fieldset on_validation_error
+                fieldset show_required_p on_validation_error csrf_protection_p
             }} {
                 set af_parts(${form_name}__extend) ""
             }


### PR DESCRIPTION
Add csrf_protection_p and show_required_p to the exclusion list so they can be specified in the call of a split ad_form. Previously, placing csrf_protection_p in the first call caused key processing to run before edit_request was registered, producing an error in edit mode only. Adding csrf_protection_p in the second call causes the __csrf_token element to never be created in the form, as it was called with -extend.